### PR TITLE
Add http -> https redirect to routes where it was missing

### DIFF
--- a/charts/gitlab/templates/rt-gitlab.yaml
+++ b/charts/gitlab/templates/rt-gitlab.yaml
@@ -11,6 +11,7 @@ spec:
     targetPort: http
   tls:
     termination: edge
+    insecureEdgeTerminationPolicy: Redirect
   to:
     kind: Service
     name: gitlab

--- a/charts/sonarqube/templates/route-sonarqube.yaml
+++ b/charts/sonarqube/templates/route-sonarqube.yaml
@@ -9,6 +9,7 @@ spec:
     targetPort: 9000-tcp
   tls:
     termination: edge
+    insecureEdgeTerminationPolicy: Redirect
   to:
     kind: Service
     name: sonarqube


### PR DESCRIPTION
Gitlab and Sonarqube were missing http redirects resulting in failures when accessing the hostname. 